### PR TITLE
Double report blocked

### DIFF
--- a/interceptor.py
+++ b/interceptor.py
@@ -17,12 +17,14 @@ INTERCEPTOR_UPSTREAM_DNS_PORT = int(os.environ["INTERCEPTOR_UPSTREAM_DNS_SERVER_
 PORT = int(os.environ["INTERCEPTOR_PORT"])
 
 class MapResolver(client.Resolver):
-    def __init__(self, servers, blocked_countries_list, ip2location_bin_file_path='IP2LOCATION-LITE-DB1.BIN', ip2location_mode='SHARED_MEMORY', domain_data_db_file=DB_FILE_NAME):
+    def __init__(self, servers, blocked_countries_list, ip2location_bin_file_path='IP2LOCATION-LITE-DB1.BIN', ip2location_mode='SHARED_MEMORY', domain_data_db_file=DB_FILE_NAME, whitelist_cache_sec=30):
         client.Resolver.__init__(self, servers=servers)
 
         self.pi_hole_client = PiHoleAdmin(os.environ['PI_HOLE_URL'], pi_hole_password_env_var="PI_HOLE_PW")
 
         self.last_whitelist_refresh_time = None
+
+        self.whitelist_cache_sec = whitelist_cache_sec
 
         self.blocked_countries_list = list(blocked_countries_list)
 
@@ -59,7 +61,7 @@ class MapResolver(client.Resolver):
         else:
             do_refresh = False
 
-        applicable_whitelist_entries = self.pi_hole_client.get_whitelist_or_blacklist_entries_containing_domain(name.decode('utf-8'), ltype='white', bust_cache=do_refresh, wildcard=True)
+        applicable_whitelist_entries = self.pi_hole_client.get_whitelist_or_blacklist_entries_containing_domain(name.decode('utf-8'), ltype='white', bust_cache=do_refresh, wildcard=True, only_enabled=True)
 
         print(f"Applicable whitelist entries for domain {name} are {applicable_whitelist_entries}")
 

--- a/interceptor.py
+++ b/interceptor.py
@@ -56,6 +56,7 @@ class MapResolver(client.Resolver):
         right_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
         if self.last_whitelist_refresh_time is None or right_now - self.last_whitelist_refresh_time > datetime.timedelta(seconds=self.whitelist_cache_sec):
+            print(f"Doing refresh. Current time is {right_now}, last time was {self.last_whitelist_refresh_time}")
             do_refresh = True
             self.last_whitelist_refresh_time = right_now
         else:
@@ -63,7 +64,8 @@ class MapResolver(client.Resolver):
 
         applicable_whitelist_entries = self.pi_hole_client.get_whitelist_or_blacklist_entries_containing_domain(name.decode('utf-8'), ltype='white', bust_cache=do_refresh, wildcard=True, only_enabled=True)
 
-        print(f"Applicable whitelist entries for domain {name} are {applicable_whitelist_entries}")
+        if do_refresh:
+            print(f"Applicable whitelist entries for domain {name} are {applicable_whitelist_entries}")
 
         reason, response = self.assess_found_ips(value, applicable_whitelist_entries is not None and applicable_whitelist_entries != [])
 

--- a/interceptor.py
+++ b/interceptor.py
@@ -35,7 +35,7 @@ class MapResolver(client.Resolver):
         self.domain_data_db_file = domain_data_db_file
 
     def get_domain_from_fqdn(self, fqdn):
-        result = tldextract.extract(fqdn)
+        result = tldextract.TLDExtract(cache_dir=os.environ['TLDEXTRACT_CACHE'])(fqdn)
 
         if result.suffix is not None and result.suffix.strip() != '':
             return f"{result.domain}.{result.suffix}"

--- a/interceptor.py
+++ b/interceptor.py
@@ -17,7 +17,7 @@ INTERCEPTOR_UPSTREAM_DNS_PORT = int(os.environ["INTERCEPTOR_UPSTREAM_DNS_SERVER_
 PORT = int(os.environ["INTERCEPTOR_PORT"])
 
 class MapResolver(client.Resolver):
-    def __init__(self, servers, blocked_countries_list, ip2location_bin_file_path='IP2LOCATION-LITE-DB1.BIN', ip2location_mode='SHARED_MEMORY', domain_data_db_file=DB_FILE_NAME, whitelist_cache_sec=30):
+    def __init__(self, servers, blocked_countries_list, ip2location_bin_file_path='IP2LOCATION-LITE-DB1.BIN', ip2location_mode='SHARED_MEMORY', domain_data_db_file=DB_FILE_NAME, whitelist_cache_sec=180):
         client.Resolver.__init__(self, servers=servers)
 
         self.pi_hole_client = PiHoleAdmin(os.environ['PI_HOLE_URL'], pi_hole_password_env_var="PI_HOLE_PW")

--- a/interceptor.py
+++ b/interceptor.py
@@ -52,7 +52,8 @@ class MapResolver(client.Resolver):
 
     def assess_and_log_reason(self, value, name):
         right_now = datetime.datetime.now(tz=datetime.timezone.utc)
-        if self.last_whitelist_refresh_time is None or right_now - self.last_whitelist_refresh_time > datetime.timedelta(seconds=self.whitelist_cache_sec)
+
+        if self.last_whitelist_refresh_time is None or right_now - self.last_whitelist_refresh_time > datetime.timedelta(seconds=self.whitelist_cache_sec):
             do_refresh = True
             self.last_whitelist_refresh_time = right_now
         else:

--- a/new_domain_alert.py
+++ b/new_domain_alert.py
@@ -42,7 +42,7 @@ def main():
     print(f"Starting blacklist assessment at {start} sec since epoch")
 
     previously_unseen_blocked_domain_data = windower_blacklist.get_previously_unseen_domains()
-
+ 
     sqlite_utils.log_reason(DB_FILE_NAME, [{'domain': domain, 'first_time_seen': seen_time, 'last_time_seen': seen_time, 'permitted': False, "reason": "Blocked by PiHole"} for domain, seen_time in previously_unseen_blocked_domain_data.items()], updateable_fields=['permitted', 'reason', 'last_time_seen'])
 
     sqlite_utils.notify_of_new_domains_in_interval(DB_FILE_NAME, windower_blacklist._window_oldest_bound, windower_blacklist._window_newest_bound, False, os.environ['ADMIN_PHONE'], os.environ['TWILIO_PHONE'])
@@ -54,9 +54,7 @@ def main():
     print(f"Starting whitelist assessment at {start} sec since epoch")
 
     # Don't log "permitted" domains (according to pihole API) to DB because interceptor.py has the final say on what is permitted, so no updates or inserts should be necessary on permitted domains from the PiHole API.
-    # Instead, advance the window and perform notification based on data already in DB.
-    windower_whitelist.update_window()
-
+    # Instead, just perform notification based on data already in DB.
     sqlite_utils.notify_of_new_domains_in_interval(DB_FILE_NAME, windower_whitelist._window_oldest_bound, windower_whitelist._window_newest_bound, True, os.environ['ADMIN_PHONE'], os.environ['TWILIO_PHONE'])
 
     print(f"Finished whitelist assessment in {time.time() - start} sec")

--- a/new_domain_alert.py
+++ b/new_domain_alert.py
@@ -1,7 +1,6 @@
 import os
 import time
 from constants import DB_FILE_NAME
-import twilio_utils
 from pi_hole_admin import PiHoleAdmin
 from unique_domains_windower import UniqueDomainsWindower
 import sqlite_utils

--- a/new_domain_alert.py
+++ b/new_domain_alert.py
@@ -31,18 +31,13 @@ def main():
     print(f"Finished blacklist init in {time.time() - start} sec")
 
     start = time.time()
-    print(f"Starting whitelist init at {start} sec since epoch")
-
-    windower_whitelist = initialize_default_windower(os.environ['PI_HOLE_URL'], 'windower_whitelist.bin', PiHoleAdmin.ALL_PERMITTED, True)
-
-    print(f"Finished whitelist init in {time.time() - start} sec")
-
-    start = time.time()
 
     print(f"Starting blacklist assessment at {start} sec since epoch")
 
     previously_unseen_blocked_domain_data = windower_blacklist.get_previously_unseen_domains()
  
+    oldest_bound, newest_bound = windower_blacklist.get_time_interval()
+
     sqlite_utils.log_reason(DB_FILE_NAME, [{'domain': domain, 'first_time_seen': seen_time, 'last_time_seen': seen_time, 'permitted': False, "reason": "Blocked by PiHole"} for domain, seen_time in previously_unseen_blocked_domain_data.items()], updateable_fields=['permitted', 'reason', 'last_time_seen'])
 
     sqlite_utils.notify_of_new_domains_in_interval(DB_FILE_NAME, windower_blacklist._window_oldest_bound, windower_blacklist._window_newest_bound, False, os.environ['ADMIN_PHONE'], os.environ['TWILIO_PHONE'])
@@ -55,7 +50,7 @@ def main():
 
     # Don't log "permitted" domains (according to pihole API) to DB because interceptor.py has the final say on what is permitted, so no updates or inserts should be necessary on permitted domains from the PiHole API.
     # Instead, just perform notification based on data already in DB.
-    sqlite_utils.notify_of_new_domains_in_interval(DB_FILE_NAME, windower_whitelist._window_oldest_bound, windower_whitelist._window_newest_bound, True, os.environ['ADMIN_PHONE'], os.environ['TWILIO_PHONE'])
+    sqlite_utils.notify_of_new_domains_in_interval(DB_FILE_NAME, oldest_bound, newest_bound, True, os.environ['ADMIN_PHONE'], os.environ['TWILIO_PHONE'])
 
     print(f"Finished whitelist assessment in {time.time() - start} sec")
 

--- a/pi_hole_admin.py
+++ b/pi_hole_admin.py
@@ -65,12 +65,12 @@ class PiHoleAdmin(object):
 
         for entry in self.get_whitelist_or_blacklist_entries(bust_cache=bust_cache, ltype=ltype_clean, only_enabled=only_enabled):
             if ltype_clean == 'white':
-                if wildcard and entry["type"] == 2 and (re.fullmatch(entry["domain"], domain) or domain == entry["domain"]):
+                if wildcard and entry["type"] == 2 and (re.match(entry["domain"], domain) or domain == entry["domain"]):
                     containing_entries.append(entry)
                 elif not wildcard and entry["type"] == 0 and entry["domain"] == domain:
                     containing_entries.append(entry)
             else:
-                if wildcard and entry["type"] == 3 and (re.fullmatch(entry["domain"], domain) or domain == entry["domain"]):
+                if wildcard and entry["type"] == 3 and (re.match(entry["domain"], domain) or domain == entry["domain"]):
                     containing_entries.append(entry)
                 elif not wildcard and entry["type"] == 1 and entry["domain"] == domain:
                     containing_entries.append(entry)

--- a/pi_hole_admin.py
+++ b/pi_hole_admin.py
@@ -65,12 +65,12 @@ class PiHoleAdmin(object):
 
         for entry in self.get_whitelist_or_blacklist_entries(bust_cache=bust_cache, ltype=ltype_clean, only_enabled=only_enabled):
             if ltype_clean == 'white':
-                if wildcard and entry["type"] == 2 and (re.match(entry["domain"], domain) or domain == entry["domain"]):
+                if wildcard and entry["type"] == 2 and (re.match(f".*{entry['domain']}", domain) or domain == entry["domain"]):
                     containing_entries.append(entry)
                 elif not wildcard and entry["type"] == 0 and entry["domain"] == domain:
                     containing_entries.append(entry)
             else:
-                if wildcard and entry["type"] == 3 and (re.match(entry["domain"], domain) or domain == entry["domain"]):
+                if wildcard and entry["type"] == 3 and (re.match(f".*{entry['domain']}", domain) or domain == entry["domain"]):
                     containing_entries.append(entry)
                 elif not wildcard and entry["type"] == 1 and entry["domain"] == domain:
                     containing_entries.append(entry)

--- a/pi_hole_admin.py
+++ b/pi_hole_admin.py
@@ -363,7 +363,7 @@ class PiHoleAdmin(object):
             if not only_domains:
                 unique_domains.add(query['record'][1])
             else:
-                result = tldextract.extract(query['record'][1])
+                result = tldextract.TLDExtract(cache_dir=os.environ['TLDEXTRACT_CACHE'])(query['record'][1])
 
                 if result.suffix is not None and result.suffix.strip() != '':
                     unique_domains.add(f"{result.domain}.{result.suffix}")

--- a/pi_hole_admin.py
+++ b/pi_hole_admin.py
@@ -50,11 +50,11 @@ class PiHoleAdmin(object):
 
         return self._php_session_id
 
-    def get_whitelist_or_blacklist_entries_containing_domain(self, domain: str, ltype: str, bust_cache: bool=False, wildcard: bool=False):
+    def get_whitelist_or_blacklist_entries_containing_domain(self, domain: str, ltype: str, bust_cache: bool=False, wildcard: bool=False, only_enabled=False):
         """
         Determines whether the current whitelist or blacklist entries contain
-        the proposed domain. Returns list of all matching list entries. Does
-        not distinguish between enabled and disabled groups.
+        the proposed domain. Returns list of all matching list entries. Will
+        distinguish between enabled and disabled groups if only_enabled = True
         """
         if ltype is None or ltype.lower().strip() not in ['white', 'black']:
             raise ValueError(f"Invalid list type: \"{ltype}\"")
@@ -63,7 +63,7 @@ class PiHoleAdmin(object):
 
         containing_entries = []
 
-        for entry in self.get_whitelist_or_blacklist_entries(bust_cache=bust_cache, ltype=ltype_clean):
+        for entry in self.get_whitelist_or_blacklist_entries(bust_cache=bust_cache, ltype=ltype_clean, only_enabled=only_enabled):
             if ltype_clean == 'white':
                 if wildcard and entry["type"] == 2 and (re.fullmatch(entry["domain"], domain) or domain == entry["domain"]):
                     containing_entries.append(entry)
@@ -122,7 +122,7 @@ class PiHoleAdmin(object):
         if verbose:
             print(msg)
 
-    def get_whitelist_or_blacklist_entries(self, ltype: str, bust_cache: bool=False):
+    def get_whitelist_or_blacklist_entries(self, ltype: str, bust_cache: bool=False, only_enabled=False):
         """
         Get entries from whitelist if list type `ltype` is 'white' or blacklist
         if list type `ltype` is 'black'.
@@ -156,11 +156,11 @@ class PiHoleAdmin(object):
         response_json = response.json()
 
         if ltype_clean == 'white':
-            self._whitelist_entries = [datum for datum in response_json.get("data", [])]
+            self._whitelist_entries = [datum for datum in response_json.get("data", []) if not only_enabled or int(datum['enabled']) != 0]
 
             return self._whitelist_entries
         if ltype_clean == 'black':
-            self._blacklist_entries = [datum for datum in response_json.get("data", [])]
+            self._blacklist_entries = [datum for datum in response_json.get("data", []) if not only_enabled or int(datum['enabled']) != 0]
 
             return self._blacklist_entries
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ requests==2.26.0
 tldextract==3.1.2
 twilio==7.4.0
 Twisted==21.7.0
-IP2Location==8.6.4
+IP2Location==8.8.1
 django==3.2.13
 django-filter==21.1

--- a/start_interceptor.sh
+++ b/start_interceptor.sh
@@ -19,6 +19,8 @@ fi
 
 export PYTHONPATH=$PYTHONPATH:/home/pi/domovoi:.
 
+set LOWER_WHITELIST_CACHE_SEC_LIMIT=30
+
 if [ "$INTERCEPTOR_PORT" == "" ]; then
         export INTERCEPTOR_PORT='47786'
 fi
@@ -68,6 +70,16 @@ fi
 if [ "$ADMIN_PHONE" == "" ]; then
         echo "No ADMIN_PHONE environment variable defined. Please try again."
         exit 8
+fi
+
+if [ "$WHITELIST_CACHE_SEC" == "" ]; then
+        echo "No WHITELIST_CACHE_SEC environment variable defined. Please try again."
+        exit 9
+else
+        if [ $WHITELIST_CACHE_SEC -lt $LOWER_WHITELIST_CACHE_SEC_LIMIT ]; then
+                echo "Invalid WHITELIST_CACHE_SEC  ('$WHITELIST_CACHE_SEC') environment variable defined. Please try a number at least $LOWER_WHITELIST_CACHE_SEC_LIMIT seconds."
+                exit 10
+        fi
 fi
 
 if [ -f "./twistd.pid" ]; then

--- a/start_interceptor.sh
+++ b/start_interceptor.sh
@@ -19,8 +19,6 @@ fi
 
 export PYTHONPATH=$PYTHONPATH:/home/pi/domovoi:.
 
-set LOWER_WHITELIST_CACHE_SEC_LIMIT=30
-
 if [ "$INTERCEPTOR_PORT" == "" ]; then
         export INTERCEPTOR_PORT='47786'
 fi
@@ -73,14 +71,14 @@ if [ "$ADMIN_PHONE" == "" ]; then
 fi
 
 if [ "$WHITELIST_CACHE_SEC" == "" ]; then
-        echo "No WHITELIST_CACHE_SEC environment variable defined. Please try again."
-        exit 9
-else
-        if [ $WHITELIST_CACHE_SEC -lt $LOWER_WHITELIST_CACHE_SEC_LIMIT ]; then
-                echo "Invalid WHITELIST_CACHE_SEC  ('$WHITELIST_CACHE_SEC') environment variable defined. Please try a number at least $LOWER_WHITELIST_CACHE_SEC_LIMIT seconds."
-                exit 10
-        fi
+        export WHITELIST_CACHE_SEC=30
 fi
+
+if [ $WHITELIST_CACHE_SEC -lt 30 ]; then
+        echo "Invalid WHITELIST_CACHE_SEC  ('$WHITELIST_CACHE_SEC') environment variable defined. Please try a number at least 30 seconds."
+        exit 10
+fi
+
 
 if [ -f "./twistd.pid" ]; then
         /bin/rm -f ./twistd.pid

--- a/start_interceptor.sh
+++ b/start_interceptor.sh
@@ -47,7 +47,7 @@ if [ "$TLDEXTRACT_CACHE" == ""]; then
         export TLDEXTRACT_CACHE="$pwd/.tldextract_cache_dir/"
 fi
 
-/usr/bin/mkdir -p $TLDEXTRACT_CACHE
+/usr/bin/mkdir -p "$TLDEXTRACT_CACHE"
 
 if [ ! -f ".twilio_creds" ]; then
         echo "No .twilio_creds file found. Please try again."

--- a/start_interceptor.sh
+++ b/start_interceptor.sh
@@ -43,6 +43,12 @@ if [ "$BLOCKED_COUNTRIES_LIST" == "" ]; then
         export BLOCKED_COUNTRIES_LIST="ru,ir,cn,kp,hk,tr,bg,by,sy,la,kh,th,ph,vn,mm,mn,mk,mo,af,al,rs,ba,si,hr,iq,ae,sa,ye,eg,lb,cy,pk,in,bd,bt,bh,qa,kw,kz,kg,tj,tm,uz,am,az,lk,ro,me,md,cu,il,sk,br"
 fi
 
+if [ "$TLDEXTRACT_CACHE" == ""]; then
+        export TLDEXTRACT_CACHE="$pwd/.tldextract_cache_dir/"
+fi
+
+/usr/bin/mkdir -p $TLDEXTRACT_CACHE
+
 if [ ! -f ".twilio_creds" ]; then
         echo "No .twilio_creds file found. Please try again."
         exit 4

--- a/start_interceptor.sh
+++ b/start_interceptor.sh
@@ -43,37 +43,29 @@ if [ "$BLOCKED_COUNTRIES_LIST" == "" ]; then
         export BLOCKED_COUNTRIES_LIST="ru,ir,cn,kp,hk,tr,bg,by,sy,la,kh,th,ph,vn,mm,mn,mk,mo,af,al,rs,ba,si,hr,iq,ae,sa,ye,eg,lb,cy,pk,in,bd,bt,bh,qa,kw,kz,kg,tj,tm,uz,am,az,lk,ro,me,md,cu,il,sk,br"
 fi
 
-if [ "$TLDEXTRACT_CACHE" == ""]; then
-        export TLDEXTRACT_CACHE="$pwd/.tldextract_cache_dir/"
+if [ "$TLDEXTRACT_CACHE" == "" ]; then
+        export TLDEXTRACT_CACHE="/home/pi/domovoi/.tldextract_cache_dir/"
 fi
 
 /usr/bin/mkdir -p "$TLDEXTRACT_CACHE"
+
+chmod ugo+rwx -R "$TLDEXTRACT_CACHE"
 
 if [ ! -f ".twilio_creds" ]; then
         echo "No .twilio_creds file found. Please try again."
         exit 4
 fi
 
-source ./.twilio_creds;
+source ./.twilio_creds
 
-if [ "$TWILIO_PHONE" == "" ]; then
-        echo "No TWILIO_PHONE environment variable defined. Please try again."
+if [ "$PI_HOLE_PW" == "" ]; then
+        echo "No PI_HOLE_PW environment variable defined. Please try again."
         exit 5
 fi
 
-if [ "$TWILIO_ACCOUNT_SID" == "" ]; then
-    echo "No TWILIO_ACCOUNT_SID environment variable defined. Please try again."
-        exit 6
-fi
-
-if [ "$TWILIO_AUTH_TOKEN" == "" ]; then
-        echo "No TWILIO_AUTH_TOKEN environment variable defined. Please try again."
-        exit 7
-fi
-
-if [ "$ADMIN_PHONE" == "" ]; then
-        echo "No ADMIN_PHONE environment variable defined. Please try again."
-        exit 8
+if [ "$PI_HOLE_URL" == "" ]; then
+        echo "No PI_HOLE_URL environment variable defined. Please try again."
+        exit 5
 fi
 
 if [ "$WHITELIST_CACHE_SEC" == "" ]; then
@@ -84,7 +76,6 @@ if [ $WHITELIST_CACHE_SEC -lt 30 ]; then
         echo "Invalid WHITELIST_CACHE_SEC  ('$WHITELIST_CACHE_SEC') environment variable defined. Please set cache time to at least 30 seconds."
         exit 9
 fi
-
 
 if [ -f "./twistd.pid" ]; then
         /bin/rm -f ./twistd.pid

--- a/start_interceptor.sh
+++ b/start_interceptor.sh
@@ -71,12 +71,12 @@ if [ "$ADMIN_PHONE" == "" ]; then
 fi
 
 if [ "$WHITELIST_CACHE_SEC" == "" ]; then
-        export WHITELIST_CACHE_SEC=30
+        export WHITELIST_CACHE_SEC=180
 fi
 
 if [ $WHITELIST_CACHE_SEC -lt 30 ]; then
-        echo "Invalid WHITELIST_CACHE_SEC  ('$WHITELIST_CACHE_SEC') environment variable defined. Please try a number at least 30 seconds."
-        exit 10
+        echo "Invalid WHITELIST_CACHE_SEC  ('$WHITELIST_CACHE_SEC') environment variable defined. Please set cache time to at least 30 seconds."
+        exit 9
 fi
 
 

--- a/unique_domains_windower.py
+++ b/unique_domains_windower.py
@@ -31,7 +31,7 @@ class UniqueDomainsWindower(object):
         self._client = client
         self._unique_domains_file = unique_domains_file
 
-        self._unique_domains_window = {domain: self._window_newest_bound for domain in self._client.get_unique_domains_between_times(self._window_oldest_bound, self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
+        self._unique_domains_window = {domain: self._window_oldest_bound for domain in self._client.get_unique_domains_between_times(self._window_oldest_bound, self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
 
         self.save_to_file()
 

--- a/unique_domains_windower.py
+++ b/unique_domains_windower.py
@@ -89,7 +89,8 @@ class UniqueDomainsWindower(object):
         if self._verbose:
             print(f"New interval: [{older_bound}, {newer_bound}]")
 
-        UniqueDomainsWindower._get_domains_in_interval(self)
+        # update via pi-hole here since we need to know what pi-hole has permitted or blocked (depending upon the dns types) in the updated interval.
+        self._unique_domains_window = {domain: self._window_oldest_bound for domain in self._client.get_unique_domains_between_times(self._window_oldest_bound, self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
 
         current_domains = {key: value for key, value in self._unique_domains_window.items()}
 

--- a/unique_domains_windower.py
+++ b/unique_domains_windower.py
@@ -51,9 +51,9 @@ class UniqueDomainsWindower(object):
         windower._client = client
 
         if windower._types == PiHoleAdmin.ALL_PERMITTED:
-            windower._unique_domains_window = sqlite_utils.get_domains_in_interval(DB_FILE_NAME, windower._window_oldest_bound, windower._window_newest_bound, True, False)
+            windower._unique_domains_window = {domain: windower._window_newest_bound for domain in sqlite_utils.get_domains_in_interval(DB_FILE_NAME, windower._window_oldest_bound, windower._window_newest_bound, True, False)}
         elif windower._types == PiHoleAdmin.ALL_BLOCKED:
-            windower._unique_domains_window = sqlite_utils.get_domains_in_interval(DB_FILE_NAME, windower._window_oldest_bound, windower._window_newest_bound, False, False)
+            windower._unique_domains_window = {domain: windower._window_newest_bound for domain in sqlite_utils.get_domains_in_interval(DB_FILE_NAME, windower._window_oldest_bound, windower._window_newest_bound, False, False)}
         else:
             raise ValueError(f"unknown windower types: {windower._types}")
 

--- a/unique_domains_windower.py
+++ b/unique_domains_windower.py
@@ -36,7 +36,7 @@ class UniqueDomainsWindower(object):
         self.save_to_file()
 
     @classmethod
-    def _get_domains_in_interval(windower):
+    def _get_domains_in_interval(cls, windower):
         if windower._types == PiHoleAdmin.ALL_PERMITTED:
             windower._unique_domains_window = {domain: windower._window_newest_bound for domain in sqlite_utils.get_domains_in_interval(DB_FILE_NAME, windower._window_oldest_bound, windower._window_newest_bound, True, False)}
         elif windower._types == PiHoleAdmin.ALL_BLOCKED:

--- a/unique_domains_windower.py
+++ b/unique_domains_windower.py
@@ -3,6 +3,7 @@ import datetime
 from copy import deepcopy
 import pickle
 from constants import DB_FILE_NAME
+import sqlite_utils
 
 class UniqueDomainsWindower(object):
     """

--- a/unique_domains_windower.py
+++ b/unique_domains_windower.py
@@ -29,9 +29,9 @@ class UniqueDomainsWindower(object):
         self._client = client
         self._unique_domains_file = unique_domains_file
 
-        self._unique_domains_window = {domain: self._window_newest_bound for domain in self._client.get_unique_domains_between_times(self._window_oldest_bound, self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
-    
         self.save_to_file()
+
+        self._unique_domains_window = {domain: self._window_newest_bound for domain in self._client.get_unique_domains_between_times(self._window_oldest_bound, self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
 
     @classmethod
     def deserialize(cls, client: PiHoleAdmin, unique_domains_file: str, verbose: bool=True):
@@ -73,6 +73,11 @@ class UniqueDomainsWindower(object):
         return newly_seen_domains
 
     def save_to_file(self):
+        # Don't save unique domains to a file since sqlite file should be
+        # source of truth on what domains have been permitted and which
+        # haven't.
+        self._unique_domains_window = None
+
         if self._unique_domains_file is not None:
             print(f"Saving domains to file {self._unique_domains_file}")
 
@@ -83,23 +88,5 @@ class UniqueDomainsWindower(object):
         self._window_oldest_bound = deepcopy(self._window_newest_bound)
 
         self._window_newest_bound = datetime.datetime.now(tz=datetime.timezone.utc)
-
-        cutoff = self._window_newest_bound - datetime.timedelta(seconds=self._window_size_sec)
-
-        if self._window_newest_bound - self._window_oldest_bound > datetime.timedelta(seconds=self._interval_sec):
-            if self._verbose:
-                print("Interval is insufficient")
-            new_domains = {domain: self._window_newest_bound for domain in self._client.get_unique_domains_between_times(self._window_oldest_bound, self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
-        else:
-            if self._verbose:
-                print("Interval is sufficient")
-            new_domains = {domain: self._window_newest_bound for domain in self._client.get_unique_domains_between_times(self._window_newest_bound - datetime.timedelta(seconds=self._interval_sec), self._window_newest_bound, self._types, self._excluded_dns_types, self._interval_sec, self._only_domains, self._verbose)}
-
-        if self._verbose:
-            print(f"Found new domains {new_domains}")
-
-        self._unique_domains_window.update(new_domains)
-        
-        self._unique_domains_window = dict(filter(lambda item: item[1] >= cutoff, self._unique_domains_window.items()))
 
         self.save_to_file()


### PR DESCRIPTION
- Stop double-reporting blocked domains.
- Synchronize reporting intervals for permitted and blocked domains.
- Enable caching of TLDs for tldextract.
- Check to make sure PI_HOLE_URL and PI_HOLE_PW are provided after sourcing .twilio_creds in start_interceptor.sh
- Remove need for separate whitelist windower file.
- Deduplicated blocked/permitted domain storage to the .db file instead of having separate .bin files to store domains (domain instance variable is still persisted to file, but is nullified before persistence to avoid duplicating data). This should greatly reduce the potential for data integrity issues in reporting.